### PR TITLE
Move unversioned endpoints (status/servertime/tradingview history) from rest-v3.md to rest-v1.md

### DIFF
--- a/rest-v1.md
+++ b/rest-v1.md
@@ -45,8 +45,6 @@ N/A — V1 used a different authentication mechanism (API key in query string). 
 | /api/status | GET | N/A — unversioned, no replacement |
 | /tradingview/history | GET | N/A — unversioned, no replacement |
 
----
-
 ### GET /api/status
 
 #### Description:
@@ -152,6 +150,8 @@ curl --location 'https://api.bitkub.com/tradingview/history?symbol=BTC_THB&resol
 
 #### Field Descriptions:
 N/A
+
+---
 
 ## Additional
 

--- a/rest-v1.md
+++ b/rest-v1.md
@@ -2,7 +2,7 @@
 
 ## Announcement
 
-N/A — V1 endpoints have been removed.
+N/A — V1 endpoints have been removed, except GET /api/status, GET /api/servertime, and GET /tradingview/history, which remain active (unversioned).
 
 ## Change Log
 
@@ -41,6 +41,111 @@ N/A — V1 used a different authentication mechanism (API key in query string). 
 | /api/market/my-open-orders | GET | GET /api/v3/market/my-open-orders |
 | /api/market/my-order-history | GET | GET /api/v3/market/my-order-history |
 | /api/market/order-info | GET | GET /api/v3/market/order-info |
+| /api/servertime | GET | GET /api/v3/servertime |
+| /api/status | GET | N/A — unversioned, no replacement |
+| /tradingview/history | GET | N/A — unversioned, no replacement |
+
+### GET /api/status
+
+#### Description:
+Get endpoint status. When status is not `ok`, it is highly recommended to wait until the status changes back to `ok`.
+
+
+#### Required Permission:
+N/A
+
+#### Validation Rules:
+N/A
+#### Example cURL:
+```bash
+curl --location 'https://api.bitkub.com/api/status'
+```
+
+#### Response:
+```json
+[
+  {
+    "name": "Non-secure endpoints",
+    "status": "ok",
+    "message": ""
+  },
+  {
+    "name": "Secure endpoints",
+    "status": "ok",
+    "message": ""
+  }
+]
+```
+
+#### Field Descriptions:
+N/A
+
+### GET /api/servertime
+
+#### Description:
+Get server timestamp.
+
+**⚠️ DEPRECATED:** Returns seconds. Use GET /api/v3/servertime instead (returns milliseconds).
+
+
+#### Required Permission:
+N/A
+
+#### Validation Rules:
+N/A
+#### Example cURL:
+```bash
+curl --location 'https://api.bitkub.com/api/servertime'
+```
+
+#### Response:
+```json
+1707220534359
+```
+
+#### Field Descriptions:
+N/A
+
+### GET /tradingview/history
+
+#### Description:
+Get OHLCV historical data for TradingView chart integration.
+
+
+#### Required Permission:
+N/A
+#### Query Params:
+
+| Key | Type | Required | Description |
+| --- | ---- | -------- | ----------- |
+| symbol | string | true | The symbol (e.g. BTC_THB) |
+| resolution | string | true | Chart resolution: 1, 5, 15, 60, 240, 1D |
+| from | int | true | Start timestamp (Unix seconds) |
+| to | int | true | End timestamp (Unix seconds) |
+
+
+#### Validation Rules:
+N/A
+#### Example cURL:
+```bash
+curl --location 'https://api.bitkub.com/tradingview/history?symbol=BTC_THB&resolution=60&from=1633424427&to=1633427427'
+```
+
+#### Response:
+```json
+{
+  "c": [1685000, 1680699.95, 1688998.99, 1692222.22],
+  "h": [1685000, 1685000, 1689000, 1692222.22],
+  "l": [1680053.22, 1671000, 1680000, 1684995.07],
+  "o": [1682500, 1685000, 1680100, 1684995.07],
+  "s": "ok",
+  "t": [1633424400, 1633425300, 1633426200, 1633427100],
+  "v": [4.604352630000001, 8.530631670000005, 4.836581560000002, 2.851018920000002]
+}
+```
+
+#### Field Descriptions:
+N/A
 
 ## Additional
 

--- a/rest-v1.md
+++ b/rest-v1.md
@@ -45,6 +45,8 @@ N/A — V1 used a different authentication mechanism (API key in query string). 
 | /api/status | GET | N/A — unversioned, no replacement |
 | /tradingview/history | GET | N/A — unversioned, no replacement |
 
+---
+
 ### GET /api/status
 
 #### Description:
@@ -80,6 +82,8 @@ curl --location 'https://api.bitkub.com/api/status'
 #### Field Descriptions:
 N/A
 
+---
+
 ### GET /api/servertime
 
 #### Description:
@@ -105,6 +109,8 @@ curl --location 'https://api.bitkub.com/api/servertime'
 
 #### Field Descriptions:
 N/A
+
+---
 
 ### GET /tradingview/history
 

--- a/rest-v3.md
+++ b/rest-v3.md
@@ -51,12 +51,6 @@ V3 is the current stable REST API for market data and trading operations. It int
 
 ## Endpoint Index
 
-### Non-Secure Endpoints
-* [GET /api/status](#get-apistatus)
-* [GET /api/servertime](#get-apiservertime)
-* [GET /tradingview/history](#get-tradingviewhistory)
-* [GET /api/v3/servertime](#get-apiv3servertime)
-
 ### Non-Secure Endpoints V3
 
 | Market Data Endpoint | Method |
@@ -117,65 +111,6 @@ All secure endpoints require the following headers:
 
 ### Server Information
 
-### GET /api/status
-
-#### Description:
-Get endpoint status. When status is not `ok`, it is highly recommended to wait until the status changes back to `ok`.
-
-
-#### Required Permission:
-N/A
-
-#### Validation Rules:
-N/A
-#### Example cURL:
-```bash
-curl --location 'https://api.bitkub.com/api/status'
-```
-
-#### Response:
-```json
-[
-  {
-    "name": "Non-secure endpoints",
-    "status": "ok",
-    "message": ""
-  },
-  {
-    "name": "Secure endpoints",
-    "status": "ok",
-    "message": ""
-  }
-]
-```
-
-#### Field Descriptions:
-N/A
-### GET /api/servertime
-
-#### Description:
-Get server timestamp.
-
-**⚠️ DEPRECATED:** Returns seconds. Use GET /api/v3/servertime instead (returns milliseconds).
-
-
-#### Required Permission:
-N/A
-
-#### Validation Rules:
-N/A
-#### Example cURL:
-```bash
-curl --location 'https://api.bitkub.com/api/servertime'
-```
-
-#### Response:
-```json
-1707220534359
-```
-
-#### Field Descriptions:
-N/A
 ### GET /api/v3/servertime
 
 #### Description:
@@ -451,48 +386,6 @@ curl --location 'https://api.bitkub.com/api/v3/market/trades?sym=btc_thb&lmt=5'
     [1734661894000, 3367353.98, 0.00148484, "BUY"],
     [1734661893000, 3367353.98, 0.00029622, "BUY"]
   ]
-}
-```
-
-#### Field Descriptions:
-N/A
-### Chart Data
-
-### GET /tradingview/history
-
-#### Description:
-Get OHLCV historical data for TradingView chart integration.
-
-
-#### Required Permission:
-N/A
-#### Query Params:
-
-| Key | Type | Required | Description |
-| --- | ---- | -------- | ----------- |
-| symbol | string | true | The symbol (e.g. BTC_THB) |
-| resolution | string | true | Chart resolution: 1, 5, 15, 60, 240, 1D |
-| from | int | true | Start timestamp (Unix seconds) |
-| to | int | true | End timestamp (Unix seconds) |
-
-
-#### Validation Rules:
-N/A
-#### Example cURL:
-```bash
-curl --location 'https://api.bitkub.com/tradingview/history?symbol=BTC_THB&resolution=60&from=1633424427&to=1633427427'
-```
-
-#### Response:
-```json
-{
-  "c": [1685000, 1680699.95, 1688998.99, 1692222.22],
-  "h": [1685000, 1685000, 1689000, 1692222.22],
-  "l": [1680053.22, 1671000, 1680000, 1684995.07],
-  "o": [1682500, 1685000, 1680100, 1684995.07],
-  "s": "ok",
-  "t": [1633424400, 1633425300, 1633426200, 1633427100],
-  "v": [4.604352630000001, 8.530631670000005, 4.836581560000002, 2.851018920000002]
 }
 ```
 

--- a/rest-v3.md
+++ b/rest-v3.md
@@ -188,6 +188,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/symbols'
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### GET /api/v3/market/ticker
 
 #### Description:
@@ -229,6 +232,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/ticker?sym=btc_thb'
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### GET /api/v3/market/bids
 
 #### Description:
@@ -271,6 +277,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/bids?sym=btc_thb&lmt=5'
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### GET /api/v3/market/asks
 
 #### Description:
@@ -313,6 +322,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/asks?sym=btc_thb&lmt=5'
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### GET /api/v3/market/depth
 
 #### Description:
@@ -355,6 +367,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/depth?sym=btc_thb&lmt=5'
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### GET /api/v3/market/trades
 
 #### Description:
@@ -424,6 +439,9 @@ curl --location --request POST 'https://api.bitkub.com/api/v3/user/trading-credi
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### POST /api/v3/user/limits
 
 #### Description:
@@ -467,6 +485,9 @@ curl --location --request POST 'https://api.bitkub.com/api/v3/user/limits' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### GET /api/v3/user/coin-convert-history
 
 #### Description:
@@ -572,6 +593,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/place-bid' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### POST /api/v3/market/place-ask
 
 #### Description:
@@ -624,6 +648,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/place-ask' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### POST /api/v3/market/cancel-order
 
 #### Description:
@@ -662,6 +689,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/cancel-order' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### GET /api/v3/market/my-open-orders
 
 #### Description:
@@ -712,6 +742,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/my-open-orders?sym=btc_thb
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### GET /api/v3/market/my-order-history
 
 #### Description:
@@ -830,6 +863,8 @@ curl --location 'https://api.bitkub.com/api/v3/market/my-order-history?sym=BTC_T
 | amount | string | Order amount |
 | ts | number | Order close timestamp (milliseconds) |
 | order_closed_at | number | Order closure timestamp (milliseconds, nullable) |
+
+---
 
 ### GET /api/v3/market/order-info
 

--- a/rest-v3.md
+++ b/rest-v3.md
@@ -2,22 +2,22 @@
 
 ## Announcement
 
-* Fiat deposit and withdraw history older than 90 days is archived for [deposits](restful-api-v4.md#get-apiv4fiatdeposithistory) and [withdraws](restful-api-v4.md#get-apiv4fiatwithdrawhistory). More details [here](https://support.bitkub.com/en/solutions/articles?id=KM000009940).
-* Crypto deposit and withdraw history older than 90 days is archived for [deposits](restful-api-v4.md#get-apiv4cryptodeposits) and [withdraws](restful-api-v4.md#get-apiv4cryptowithdraws). More details [here](https://support.bitkub.com/en/solutions/articles?id=KM000009898).
-* `/api/v3/market/wallet` and `/api/v3/market/balances` are deprecated. Please migrate to [GET /api/v4/wallet/balances](restful-api-v4.md#get-apiv4walletbalances) and [GET /api/v4/wallet/assets](restful-api-v4.md#get-apiv4walletassets) as replacements.
-* Fiat v3 endpoints will be deprecated on 09 June 2026.** Please migrate to [Fiat v4 endpoints](restful-api-v4.md) as replacement: [POST /api/v3/fiat/accounts](#post-apiv3fiataccounts), [POST /api/v3/fiat/withdraw](#post-apiv3fiatwithdraw), [POST /api/v3/fiat/deposit-history](#post-apiv3fiatdeposit-history), [POST /api/v3/fiat/withdraw-history](#post-apiv3fiatwithdraw-history)
+* Fiat deposit and withdraw history older than 90 days is archived for [deposits](rest-v4.md#get-apiv4fiatdeposithistory) and [withdraws](rest-v4.md#get-apiv4fiatwithdrawhistory). More details [here](https://support.bitkub.com/en/solutions/articles?id=KM000009940).
+* Crypto deposit and withdraw history older than 90 days is archived for [deposits](rest-v4.md#get-apiv4cryptodeposits) and [withdraws](rest-v4.md#get-apiv4cryptowithdraws). More details [here](https://support.bitkub.com/en/solutions/articles?id=KM000009898).
+* `/api/v3/market/wallet` and `/api/v3/market/balances` are deprecated. Please migrate to [GET /api/v4/wallet/balances](rest-v4.md#get-apiv4walletbalances) and [GET /api/v4/wallet/assets](rest-v4.md#get-apiv4walletassets) as replacements.
+* Fiat v3 endpoints will be deprecated on 09 June 2026.** Please migrate to [Fiat v4 endpoints](rest-v4.md) as replacement: [POST /api/v3/fiat/accounts](#post-apiv3fiataccounts), [POST /api/v3/fiat/withdraw](#post-apiv3fiatwithdraw), [POST /api/v3/fiat/deposit-history](#post-apiv3fiatdeposit-history), [POST /api/v3/fiat/withdraw-history](#post-apiv3fiatwithdraw-history)
 * remove status: "cancelled" from [my-order-info](#get-apiv3marketorder-info) after 3 days period. remove on 9 April 2026
 * The following market endpoints will be deprecated on 9 Dec 2025. Please use [v3 endpoints](#non-secure-endpoints-v3) as replacement: GET /api/market/symbols, GET /api/market/ticker, GET /api/market/trades, GET /api/market/bids, GET /api/market/asks, GET /api/market/books, GET /api/market/depth
 * Page-based pagination will be deprecated on 8 Sep 2025 for [my-order-history](#get-apiv3marketmy-order-history).
 * Order history older than 90 days is archived for [my-order-history](#get-apiv3marketmy-order-history) More details here.
 * order_id and txn_id formats of [my-open-orders](#get-apiv3marketmy-open-orders), [my-order-history](#get-apiv3marketmy-order-history), [my-order-info](#get-apiv3marketorder-info), [place-bid](#post-apiv3marketplace-bid), [place-ask](#post-apiv3marketplace-ask), [cancel-order](#post-apiv3marketcancel-order) may change for some symbols due to a system upgrade, See affected symbols and detail : [here](https://support.bitkub.com/en/support/solutions/articles/151000214886-announcement-trading-system-upgrade)
-* API Specifications for Crypto Endpoints, please refer to the documentation here: [Crypto Endpoints](restful-api-v4.md)
+* API Specifications for Crypto Endpoints, please refer to the documentation here: [Crypto Endpoints](rest-v4.md)
 * Deprecation of Order Hash for [my-open-orders](#get-apiv3marketmy-open-orders), [my-order-history](#get-apiv3marketmy-order-history), [my-order-info](#get-apiv3marketorder-info), [place-bid](#post-apiv3marketplace-bid), [place-ask](#post-apiv3marketplace-ask), [cancel-order](#post-apiv3marketcancel-order) on 28/02/2025 onwards, More details [here](https://support.bitkub.com/en/support/solutions/articles/151000205895-notice-deprecation-of-order-hash-from-public-api-on-28-02-2025-onwards)
 
 ## Change Log
 
-* 2026-06-09 Removed deprecated Fiat v3 endpoints: [POST /api/v3/fiat/accounts](#post-apiv3fiataccounts), [POST /api/v3/fiat/withdraw](#post-apiv3fiatwithdraw), [POST /api/v3/fiat/deposit-history](#post-apiv3fiatdeposit-history), [POST /api/v3/fiat/withdraw-history](#post-apiv3fiatwithdraw-history). Please migrate to [Fiat v4 endpoints](restful-api-v4.md).
-* 2026-05-26 Removed deprecated endpoints `/api/v3/market/wallet` and `/api/v3/market/balances`. Use [GET /api/v4/wallet/balances](restful-api-v4.md#get-apiv4walletbalances) and [GET /api/v4/wallet/assets](restful-api-v4.md#get-apiv4walletassets) instead.
+* 2026-06-09 Removed deprecated Fiat v3 endpoints: [POST /api/v3/fiat/accounts](#post-apiv3fiataccounts), [POST /api/v3/fiat/withdraw](#post-apiv3fiatwithdraw), [POST /api/v3/fiat/deposit-history](#post-apiv3fiatdeposit-history), [POST /api/v3/fiat/withdraw-history](#post-apiv3fiatwithdraw-history). Please migrate to [Fiat v4 endpoints](rest-v4.md).
+* 2026-05-26 Removed deprecated endpoints `/api/v3/market/wallet` and `/api/v3/market/balances`. Use [GET /api/v4/wallet/balances](rest-v4.md#get-apiv4walletbalances) and [GET /api/v4/wallet/assets](rest-v4.md#get-apiv4walletassets) instead.
 * 2026-04-07 Announce Fiat v4 API and deprecation of Fiat v3 endpoints on 09 June 2026
 * 2025-09-08 Update API [my-order-history](#get-apiv3marketmy-order-history) spec
 * 2025-01-07 Update FIAT Withdraw error code

--- a/rest-v3.md
+++ b/rest-v3.md
@@ -134,6 +134,9 @@ curl --location 'https://api.bitkub.com/api/v3/servertime'
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### Market Data (Read-Only)
 
 ### GET /api/v3/market/symbols
@@ -406,6 +409,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/trades?sym=btc_thb&lmt=5'
 
 #### Field Descriptions:
 N/A
+
+---
+
 ## Secure Endpoints
 
 ### User Account & Limits
@@ -539,6 +545,9 @@ curl --location 'https://api.bitkub.com/api/v3/user/coin-convert-history?p=1&lmt
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### Trading Operations
 
 ### POST /api/v3/market/place-bid
@@ -930,6 +939,8 @@ curl --location 'https://api.bitkub.com/api/v3/market/order-info?sym=btc_thb&id=
 
 #### Field Descriptions:
 N/A
+
+---
 
 ## Additional
 

--- a/rest-v4.md
+++ b/rest-v4.md
@@ -135,6 +135,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/addresses?symbol=ATOM' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### POST /api/v4/crypto/addresses
 
 #### Description:
@@ -241,6 +244,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/deposits?limit=10' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### GET /api/v4/crypto/withdraws
 
 #### Description:
@@ -302,6 +308,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/withdraws?limit=10' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### GET /api/v4/crypto/compensations
 
 #### Description:
@@ -428,6 +437,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/coins?symbol=BTC' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### POST /api/v4/crypto/withdraws
 
 #### Description:
@@ -529,6 +541,9 @@ curl --location 'https://api.bitkub.com/api/v4/wallet/balances' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### GET /api/v4/wallet/assets
 
 #### Description:
@@ -664,6 +679,9 @@ curl --location 'https://api.bitkub.com/api/v4/fiat/deposit/history?page=1&limit
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### GET /api/v4/fiat/withdraw/history
 
 #### Description:

--- a/rest-v4.md
+++ b/rest-v4.md
@@ -183,6 +183,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/addresses' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### Transaction History
 
 ### GET /api/v4/crypto/deposits
@@ -369,6 +372,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/compensations?symbol=ATOM'
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### Asset Operations
 
 ### GET /api/v4/crypto/coins
@@ -490,6 +496,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/withdraws' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ## Wallet Endpoints
 
 ### GET /api/v4/wallet/balances
@@ -583,6 +592,9 @@ curl --location 'https://api.bitkub.com/api/v4/wallet/assets' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ## Fiat Endpoints
 
 ### Account Management
@@ -631,6 +643,9 @@ curl --location 'https://api.bitkub.com/api/v4/fiat/accounts?page=1&limit=25' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### Transaction History
 
 ### GET /api/v4/fiat/deposit/history
@@ -729,6 +744,9 @@ curl --location 'https://api.bitkub.com/api/v4/fiat/withdraw/history?page=1&limi
 
 #### Field Descriptions:
 N/A
+
+---
+
 ### Fiat Operations
 
 ### POST /api/v4/fiat/withdraw
@@ -777,6 +795,9 @@ curl --location 'https://api.bitkub.com/api/v4/fiat/withdraw' \
 
 #### Field Descriptions:
 N/A
+
+---
+
 ## Additional
 
 For the use of coins and networks, please use coin or network symbol for any API request. Please refer to the link below for available coins and networks: https://www.bitkub.com/fee/cryptocurrency

--- a/websocket-private.md
+++ b/websocket-private.md
@@ -258,6 +258,8 @@ Received when your order status changes (created, filled, partially filled, canc
 | order_triggered_at | number \| null | Trigger timestamp for stop orders (Unix milliseconds) |
 | order_updated_at | number \| null | Last update timestamp (Unix milliseconds) |
 
+---
+
 ### Match Update Stream
 
 #### Name:

--- a/websocket-private.md
+++ b/websocket-private.md
@@ -327,8 +327,6 @@ Received when a trade executes (order is matched).
 
 ---
 
----
-
 ## Reference
 
 ### Stream Demo

--- a/websocket-private.md
+++ b/websocket-private.md
@@ -327,6 +327,8 @@ Received when a trade executes (order is matched).
 
 ---
 
+---
+
 ## Reference
 
 ### Stream Demo

--- a/websocket-public.md
+++ b/websocket-public.md
@@ -275,8 +275,6 @@ Real-time order book data using numeric symbol ID. Emits 5 event types: `bidscha
 
 ---
 
----
-
 ## Reference
 
 ### Stream Demo

--- a/websocket-public.md
+++ b/websocket-public.md
@@ -79,6 +79,8 @@ Real-time matched order data. Each trade contains buy order id and sell order id
 | amt    | float  | Amount matched                          |
 | ts     | int    | Trade timestamp (Unix seconds)          |
 
+---
+
 ### Ticker Stream
 
 #### Name:
@@ -129,6 +131,8 @@ Real-time ticker data. Re-calculated on every order creation, cancellation, and 
 | low24hr        | float  | Lowest price in last 24 hours            |
 | open           | float  | Open price                               |
 | close          | float  | Close price                              |
+
+---
 
 ### Live Order Book Stream
 

--- a/websocket-public.md
+++ b/websocket-public.md
@@ -275,6 +275,8 @@ Real-time order book data using numeric symbol ID. Emits 5 event types: `bidscha
 
 ---
 
+---
+
 ## Reference
 
 ### Stream Demo


### PR DESCRIPTION
## What does this PR do and why?
Follow-up to #205 (merged). One commit (`8b1740b`) was pushed to this branch after #205 already merged, so it never made it into `suwit-bitkub-new-docs`.

## Changes

**rest-v3.md / rest-v1.md**
- `GET /api/status`, `GET /api/servertime`, and `GET /tradingview/history` have no `/v3` prefix and aren't actually v3 endpoints — moved their full docs from `rest-v3.md` to `rest-v1.md`, alongside the other legacy/unversioned endpoint references there
- Dropped the now-redundant `### Non-Secure Endpoints` index heading in `rest-v3.md` (`GET /api/v3/servertime` is already listed under `Non-Secure Endpoints V3`)

## Test plan
- [ ] Confirm `rest-v3.md`'s endpoint index and content no longer reference the three moved endpoints
- [ ] Confirm `rest-v1.md` documents all three with working examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)