### PR TITLE
Separator spacing polish + consolidate Announcement into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,19 @@ Name | Description
 [rest-v4.md](./rest-v4.md)                     | Details on the RESTful API V4
 [websocket-public.md](./websocket-public.md)   | Details on the Public WebSocket API
 [websocket-private.md](./websocket-private.md) | Details on the Private WebSocket API
+
+## Announcement
+
+* Fiat deposit and withdraw history older than 90 days is archived for [deposits](rest-v4.md#get-apiv4fiatdeposithistory) and [withdraws](rest-v4.md#get-apiv4fiatwithdrawhistory). More details [here](https://support.bitkub.com/en/solutions/articles?id=KM000009940).
+* Crypto deposit and withdraw history older than 90 days is archived for [deposits](rest-v4.md#get-apiv4cryptodeposits) and [withdraws](rest-v4.md#get-apiv4cryptowithdraws). More details [here](https://support.bitkub.com/en/solutions/articles?id=KM000009898).
+* `/api/v3/market/wallet` and `/api/v3/market/balances` are deprecated. Please migrate to [GET /api/v4/wallet/balances](rest-v4.md#get-apiv4walletbalances) and [GET /api/v4/wallet/assets](rest-v4.md#get-apiv4walletassets) as replacements.
+* Fiat v3 endpoints will be deprecated on 09 June 2026.** Please migrate to [Fiat v4 endpoints](rest-v4.md) as replacement: [POST /api/v3/fiat/accounts](rest-v3.md#post-apiv3fiataccounts), [POST /api/v3/fiat/withdraw](rest-v3.md#post-apiv3fiatwithdraw), [POST /api/v3/fiat/deposit-history](rest-v3.md#post-apiv3fiatdeposit-history), [POST /api/v3/fiat/withdraw-history](rest-v3.md#post-apiv3fiatwithdraw-history)
+* remove status: "cancelled" from [my-order-info](rest-v3.md#get-apiv3marketorder-info) after 3 days period. remove on 9 April 2026
+* The following market endpoints will be deprecated on 9 Dec 2025. Please use [v3 endpoints](rest-v3.md#non-secure-endpoints-v3) as replacement: GET /api/market/symbols, GET /api/market/ticker, GET /api/market/trades, GET /api/market/bids, GET /api/market/asks, GET /api/market/books, GET /api/market/depth
+* Page-based pagination will be deprecated on 8 Sep 2025 for [my-order-history](rest-v3.md#get-apiv3marketmy-order-history).
+* Order history older than 90 days is archived for [my-order-history](rest-v3.md#get-apiv3marketmy-order-history) More details here.
+* order_id and txn_id formats of [my-open-orders](rest-v3.md#get-apiv3marketmy-open-orders), [my-order-history](rest-v3.md#get-apiv3marketmy-order-history), [my-order-info](rest-v3.md#get-apiv3marketorder-info), [place-bid](rest-v3.md#post-apiv3marketplace-bid), [place-ask](rest-v3.md#post-apiv3marketplace-ask), [cancel-order](rest-v3.md#post-apiv3marketcancel-order) may change for some symbols due to a system upgrade, See affected symbols and detail : [here](https://support.bitkub.com/en/support/solutions/articles/151000214886-announcement-trading-system-upgrade)
+* API Specifications for Crypto Endpoints, please refer to the documentation here: [Crypto Endpoints](rest-v4.md)
+* Deprecation of Order Hash for [my-open-orders](rest-v3.md#get-apiv3marketmy-open-orders), [my-order-history](rest-v3.md#get-apiv3marketmy-order-history), [my-order-info](rest-v3.md#get-apiv3marketorder-info), [place-bid](rest-v3.md#post-apiv3marketplace-bid), [place-ask](rest-v3.md#post-apiv3marketplace-ask), [cancel-order](rest-v3.md#post-apiv3marketcancel-order) on 28/02/2025 onwards, More details [here](https://support.bitkub.com/en/support/solutions/articles/151000205895-notice-deprecation-of-order-hash-from-public-api-on-28-02-2025-onwards)
+* Deposit history records are available for the last 90 days only for GET /api/v4/crypto/deposits. Records older than 90 days are archived.
+* **⚠️ 2026-05-18:** `market.trade.<symbol>` stream will be permanently closed. Please migrate to Private WebSocket.

--- a/rest-v1.md
+++ b/rest-v1.md
@@ -2,7 +2,7 @@
 
 ## Announcement
 
-N/A — V1 endpoints have been removed, except GET /api/status, GET /api/servertime, and GET /tradingview/history, which remain active (unversioned).
+N/A — see [README.md](./README.md#announcement).
 
 ## Change Log
 

--- a/rest-v1.md
+++ b/rest-v1.md
@@ -80,7 +80,9 @@ curl --location 'https://api.bitkub.com/api/status'
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/servertime
 
@@ -108,7 +110,9 @@ curl --location 'https://api.bitkub.com/api/servertime'
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /tradingview/history
 
@@ -151,7 +155,9 @@ curl --location 'https://api.bitkub.com/tradingview/history?symbol=BTC_THB&resol
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ## Additional
 

--- a/rest-v1.md
+++ b/rest-v1.md
@@ -1,9 +1,5 @@
 # REST API V1 — Deprecated
 
-## Announcement
-
-N/A — see [README.md](./README.md#announcement).
-
 ## Change Log
 
 * 2024-07-25 Deprecated and removed all V1 endpoints

--- a/rest-v1.md
+++ b/rest-v1.md
@@ -80,9 +80,11 @@ curl --location 'https://api.bitkub.com/api/status'
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/servertime
 
@@ -110,9 +112,11 @@ curl --location 'https://api.bitkub.com/api/servertime'
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /tradingview/history
 
@@ -155,9 +159,11 @@ curl --location 'https://api.bitkub.com/tradingview/history?symbol=BTC_THB&resol
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ## Additional
 

--- a/rest-v2.md
+++ b/rest-v2.md
@@ -1,9 +1,5 @@
 # REST API V2 — Deprecated
 
-## Announcement
-
-N/A — see [README.md](./README.md#announcement).
-
 ## Change Log
 
 * 2024-07-25 Deprecated and removed all V2 secure endpoints

--- a/rest-v2.md
+++ b/rest-v2.md
@@ -2,7 +2,7 @@
 
 ## Announcement
 
-N/A — V2 endpoints have been removed.
+N/A — see [README.md](./README.md#announcement).
 
 ## Change Log
 

--- a/rest-v3.md
+++ b/rest-v3.md
@@ -135,9 +135,11 @@ curl --location 'https://api.bitkub.com/api/v3/servertime'
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### Market Data (Read-Only)
 
@@ -194,9 +196,11 @@ curl --location 'https://api.bitkub.com/api/v3/market/symbols'
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v3/market/ticker
 
@@ -240,9 +244,11 @@ curl --location 'https://api.bitkub.com/api/v3/market/ticker?sym=btc_thb'
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v3/market/bids
 
@@ -287,9 +293,11 @@ curl --location 'https://api.bitkub.com/api/v3/market/bids?sym=btc_thb&lmt=5'
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v3/market/asks
 
@@ -334,9 +342,11 @@ curl --location 'https://api.bitkub.com/api/v3/market/asks?sym=btc_thb&lmt=5'
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v3/market/depth
 
@@ -381,9 +391,11 @@ curl --location 'https://api.bitkub.com/api/v3/market/depth?sym=btc_thb&lmt=5'
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v3/market/trades
 
@@ -422,9 +434,11 @@ curl --location 'https://api.bitkub.com/api/v3/market/trades?sym=btc_thb&lmt=5'
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ## Secure Endpoints
 
@@ -460,9 +474,11 @@ curl --location --request POST 'https://api.bitkub.com/api/v3/user/trading-credi
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### POST /api/v3/user/limits
 
@@ -508,9 +524,11 @@ curl --location --request POST 'https://api.bitkub.com/api/v3/user/limits' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v3/user/coin-convert-history
 
@@ -564,9 +582,11 @@ curl --location 'https://api.bitkub.com/api/v3/user/coin-convert-history?p=1&lmt
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### Trading Operations
 
@@ -623,9 +643,11 @@ curl --location 'https://api.bitkub.com/api/v3/market/place-bid' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### POST /api/v3/market/place-ask
 
@@ -680,9 +702,11 @@ curl --location 'https://api.bitkub.com/api/v3/market/place-ask' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### POST /api/v3/market/cancel-order
 
@@ -723,9 +747,11 @@ curl --location 'https://api.bitkub.com/api/v3/market/cancel-order' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v3/market/my-open-orders
 
@@ -778,9 +804,11 @@ curl --location 'https://api.bitkub.com/api/v3/market/my-open-orders?sym=btc_thb
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v3/market/my-order-history
 
@@ -901,9 +929,11 @@ curl --location 'https://api.bitkub.com/api/v3/market/my-order-history?sym=BTC_T
 | ts | number | Order close timestamp (milliseconds) |
 | order_closed_at | number | Order closure timestamp (milliseconds, nullable) |
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v3/market/order-info
 
@@ -970,9 +1000,11 @@ curl --location 'https://api.bitkub.com/api/v3/market/order-info?sym=btc_thb&id=
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ## Additional
 

--- a/rest-v3.md
+++ b/rest-v3.md
@@ -2,17 +2,7 @@
 
 ## Announcement
 
-* Fiat deposit and withdraw history older than 90 days is archived for [deposits](rest-v4.md#get-apiv4fiatdeposithistory) and [withdraws](rest-v4.md#get-apiv4fiatwithdrawhistory). More details [here](https://support.bitkub.com/en/solutions/articles?id=KM000009940).
-* Crypto deposit and withdraw history older than 90 days is archived for [deposits](rest-v4.md#get-apiv4cryptodeposits) and [withdraws](rest-v4.md#get-apiv4cryptowithdraws). More details [here](https://support.bitkub.com/en/solutions/articles?id=KM000009898).
-* `/api/v3/market/wallet` and `/api/v3/market/balances` are deprecated. Please migrate to [GET /api/v4/wallet/balances](rest-v4.md#get-apiv4walletbalances) and [GET /api/v4/wallet/assets](rest-v4.md#get-apiv4walletassets) as replacements.
-* Fiat v3 endpoints will be deprecated on 09 June 2026.** Please migrate to [Fiat v4 endpoints](rest-v4.md) as replacement: [POST /api/v3/fiat/accounts](#post-apiv3fiataccounts), [POST /api/v3/fiat/withdraw](#post-apiv3fiatwithdraw), [POST /api/v3/fiat/deposit-history](#post-apiv3fiatdeposit-history), [POST /api/v3/fiat/withdraw-history](#post-apiv3fiatwithdraw-history)
-* remove status: "cancelled" from [my-order-info](#get-apiv3marketorder-info) after 3 days period. remove on 9 April 2026
-* The following market endpoints will be deprecated on 9 Dec 2025. Please use [v3 endpoints](#non-secure-endpoints-v3) as replacement: GET /api/market/symbols, GET /api/market/ticker, GET /api/market/trades, GET /api/market/bids, GET /api/market/asks, GET /api/market/books, GET /api/market/depth
-* Page-based pagination will be deprecated on 8 Sep 2025 for [my-order-history](#get-apiv3marketmy-order-history).
-* Order history older than 90 days is archived for [my-order-history](#get-apiv3marketmy-order-history) More details here.
-* order_id and txn_id formats of [my-open-orders](#get-apiv3marketmy-open-orders), [my-order-history](#get-apiv3marketmy-order-history), [my-order-info](#get-apiv3marketorder-info), [place-bid](#post-apiv3marketplace-bid), [place-ask](#post-apiv3marketplace-ask), [cancel-order](#post-apiv3marketcancel-order) may change for some symbols due to a system upgrade, See affected symbols and detail : [here](https://support.bitkub.com/en/support/solutions/articles/151000214886-announcement-trading-system-upgrade)
-* API Specifications for Crypto Endpoints, please refer to the documentation here: [Crypto Endpoints](rest-v4.md)
-* Deprecation of Order Hash for [my-open-orders](#get-apiv3marketmy-open-orders), [my-order-history](#get-apiv3marketmy-order-history), [my-order-info](#get-apiv3marketorder-info), [place-bid](#post-apiv3marketplace-bid), [place-ask](#post-apiv3marketplace-ask), [cancel-order](#post-apiv3marketcancel-order) on 28/02/2025 onwards, More details [here](https://support.bitkub.com/en/support/solutions/articles/151000205895-notice-deprecation-of-order-hash-from-public-api-on-28-02-2025-onwards)
+N/A — see [README.md](./README.md#announcement).
 
 ## Change Log
 

--- a/rest-v3.md
+++ b/rest-v3.md
@@ -1,9 +1,5 @@
 # REST API V3
 
-## Announcement
-
-N/A — see [README.md](./README.md#announcement).
-
 ## Change Log
 
 * 2026-06-09 Removed deprecated Fiat v3 endpoints: [POST /api/v3/fiat/accounts](#post-apiv3fiataccounts), [POST /api/v3/fiat/withdraw](#post-apiv3fiatwithdraw), [POST /api/v3/fiat/deposit-history](#post-apiv3fiatdeposit-history), [POST /api/v3/fiat/withdraw-history](#post-apiv3fiatwithdraw-history). Please migrate to [Fiat v4 endpoints](rest-v4.md).

--- a/rest-v3.md
+++ b/rest-v3.md
@@ -135,7 +135,9 @@ curl --location 'https://api.bitkub.com/api/v3/servertime'
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### Market Data (Read-Only)
 
@@ -192,7 +194,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/symbols'
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/v3/market/ticker
 
@@ -236,7 +240,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/ticker?sym=btc_thb'
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/v3/market/bids
 
@@ -281,7 +287,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/bids?sym=btc_thb&lmt=5'
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/v3/market/asks
 
@@ -326,7 +334,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/asks?sym=btc_thb&lmt=5'
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/v3/market/depth
 
@@ -371,7 +381,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/depth?sym=btc_thb&lmt=5'
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/v3/market/trades
 
@@ -410,7 +422,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/trades?sym=btc_thb&lmt=5'
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ## Secure Endpoints
 
@@ -446,7 +460,9 @@ curl --location --request POST 'https://api.bitkub.com/api/v3/user/trading-credi
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### POST /api/v3/user/limits
 
@@ -492,7 +508,9 @@ curl --location --request POST 'https://api.bitkub.com/api/v3/user/limits' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/v3/user/coin-convert-history
 
@@ -546,7 +564,9 @@ curl --location 'https://api.bitkub.com/api/v3/user/coin-convert-history?p=1&lmt
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### Trading Operations
 
@@ -603,7 +623,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/place-bid' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### POST /api/v3/market/place-ask
 
@@ -658,7 +680,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/place-ask' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### POST /api/v3/market/cancel-order
 
@@ -699,7 +723,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/cancel-order' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/v3/market/my-open-orders
 
@@ -752,7 +778,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/my-open-orders?sym=btc_thb
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/v3/market/my-order-history
 
@@ -873,7 +901,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/my-order-history?sym=BTC_T
 | ts | number | Order close timestamp (milliseconds) |
 | order_closed_at | number | Order closure timestamp (milliseconds, nullable) |
 
+
 ---
+
 
 ### GET /api/v3/market/order-info
 
@@ -940,7 +970,9 @@ curl --location 'https://api.bitkub.com/api/v3/market/order-info?sym=btc_thb&id=
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ## Additional
 

--- a/rest-v4.md
+++ b/rest-v4.md
@@ -136,7 +136,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/addresses?symbol=ATOM' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### POST /api/v4/crypto/addresses
 
@@ -184,7 +186,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/addresses' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### Transaction History
 
@@ -248,7 +252,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/deposits?limit=10' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/v4/crypto/withdraws
 
@@ -312,7 +318,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/withdraws?limit=10' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/v4/crypto/compensations
 
@@ -373,7 +381,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/compensations?symbol=ATOM'
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### Asset Operations
 
@@ -444,7 +454,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/coins?symbol=BTC' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### POST /api/v4/crypto/withdraws
 
@@ -497,7 +509,9 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/withdraws' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ## Wallet Endpoints
 
@@ -551,7 +565,9 @@ curl --location 'https://api.bitkub.com/api/v4/wallet/balances' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/v4/wallet/assets
 
@@ -593,7 +609,9 @@ curl --location 'https://api.bitkub.com/api/v4/wallet/assets' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ## Fiat Endpoints
 
@@ -644,7 +662,9 @@ curl --location 'https://api.bitkub.com/api/v4/fiat/accounts?page=1&limit=25' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### Transaction History
 
@@ -695,7 +715,9 @@ curl --location 'https://api.bitkub.com/api/v4/fiat/deposit/history?page=1&limit
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### GET /api/v4/fiat/withdraw/history
 
@@ -745,7 +767,9 @@ curl --location 'https://api.bitkub.com/api/v4/fiat/withdraw/history?page=1&limi
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ### Fiat Operations
 
@@ -796,7 +820,9 @@ curl --location 'https://api.bitkub.com/api/v4/fiat/withdraw' \
 #### Field Descriptions:
 N/A
 
+
 ---
+
 
 ## Additional
 

--- a/rest-v4.md
+++ b/rest-v4.md
@@ -2,7 +2,7 @@
 
 ## Announcement
 
-* Deposit history records are available for the last 90 days only for GET /api/v4/crypto/deposits. Records older than 90 days are archived.
+N/A — see [README.md](./README.md#announcement).
 
 ## Change Log
 

--- a/rest-v4.md
+++ b/rest-v4.md
@@ -1,9 +1,5 @@
 # REST API V4
 
-## Announcement
-
-N/A — see [README.md](./README.md#announcement).
-
 ## Change Log
 
 * 2026-04-07 Introducing Fiat V4 Endpoints

--- a/rest-v4.md
+++ b/rest-v4.md
@@ -136,9 +136,11 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/addresses?symbol=ATOM' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### POST /api/v4/crypto/addresses
 
@@ -186,9 +188,11 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/addresses' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### Transaction History
 
@@ -252,9 +256,11 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/deposits?limit=10' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v4/crypto/withdraws
 
@@ -318,9 +324,11 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/withdraws?limit=10' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v4/crypto/compensations
 
@@ -381,9 +389,11 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/compensations?symbol=ATOM'
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### Asset Operations
 
@@ -454,9 +464,11 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/coins?symbol=BTC' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### POST /api/v4/crypto/withdraws
 
@@ -509,9 +521,11 @@ curl --location 'https://api.bitkub.com/api/v4/crypto/withdraws' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ## Wallet Endpoints
 
@@ -565,9 +579,11 @@ curl --location 'https://api.bitkub.com/api/v4/wallet/balances' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v4/wallet/assets
 
@@ -609,9 +625,11 @@ curl --location 'https://api.bitkub.com/api/v4/wallet/assets' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ## Fiat Endpoints
 
@@ -662,9 +680,11 @@ curl --location 'https://api.bitkub.com/api/v4/fiat/accounts?page=1&limit=25' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### Transaction History
 
@@ -715,9 +735,11 @@ curl --location 'https://api.bitkub.com/api/v4/fiat/deposit/history?page=1&limit
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### GET /api/v4/fiat/withdraw/history
 
@@ -767,9 +789,11 @@ curl --location 'https://api.bitkub.com/api/v4/fiat/withdraw/history?page=1&limi
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ### Fiat Operations
 
@@ -820,9 +844,11 @@ curl --location 'https://api.bitkub.com/api/v4/fiat/withdraw' \
 #### Field Descriptions:
 N/A
 
+<br>
 
 ---
 
+<br>
 
 ## Additional
 

--- a/websocket-private.md
+++ b/websocket-private.md
@@ -1,9 +1,5 @@
 # WebSocket API — Private
 
-## Announcement
-
-N/A — see [README.md](./README.md#announcement).
-
 ## Change Log
 
 N/A — No change log available for this API.

--- a/websocket-private.md
+++ b/websocket-private.md
@@ -18,9 +18,11 @@ The Private WebSocket API provides real-time trading data updates for authentica
 | ----------- | ------------- |
 | Production  | `wss://stream.bitkub.com/v3/private` |
 
+<br>
 
 ---
 
+<br>
 
 ## Getting Started
 
@@ -181,9 +183,11 @@ Send periodic ping messages to maintain the connection.
 }
 ```
 
+<br>
 
 ---
 
+<br>
 
 ## Data Streams
 
@@ -262,9 +266,11 @@ Received when your order status changes (created, filled, partially filled, canc
 | order_triggered_at | number \| null | Trigger timestamp for stop orders (Unix milliseconds) |
 | order_updated_at | number \| null | Last update timestamp (Unix milliseconds) |
 
+<br>
 
 ---
 
+<br>
 
 ### Match Update Stream
 
@@ -331,9 +337,11 @@ Received when a trade executes (order is matched).
 | net_fee_paid | string | Net fee paid from wallet |
 | txn_ts | number | Transaction timestamp (Unix seconds) |
 
+<br>
 
 ---
 
+<br>
 
 ## Reference
 
@@ -393,9 +401,11 @@ For backward compatibility, you can map new statuses to old statuses:
 | `429` | Too Many Connections - Maximum of 5 concurrent connections per API key exceeded |
 | `500` | Internal Server Error |
 
+<br>
 
 ---
 
+<br>
 
 ## Complete Example
 
@@ -550,9 +560,11 @@ function handleMatchUpdate(data) {
 connect();
 ```
 
+<br>
 
 ---
 
+<br>
 
 ## Security Best Practices
 

--- a/websocket-private.md
+++ b/websocket-private.md
@@ -2,7 +2,7 @@
 
 ## Announcement
 
-N/A — No announcements for this API.
+N/A — see [README.md](./README.md#announcement).
 
 ## Change Log
 

--- a/websocket-private.md
+++ b/websocket-private.md
@@ -18,7 +18,9 @@ The Private WebSocket API provides real-time trading data updates for authentica
 | ----------- | ------------- |
 | Production  | `wss://stream.bitkub.com/v3/private` |
 
+
 ---
+
 
 ## Getting Started
 
@@ -179,7 +181,9 @@ Send periodic ping messages to maintain the connection.
 }
 ```
 
+
 ---
+
 
 ## Data Streams
 
@@ -258,7 +262,9 @@ Received when your order status changes (created, filled, partially filled, canc
 | order_triggered_at | number \| null | Trigger timestamp for stop orders (Unix milliseconds) |
 | order_updated_at | number \| null | Last update timestamp (Unix milliseconds) |
 
+
 ---
+
 
 ### Match Update Stream
 
@@ -325,7 +331,9 @@ Received when a trade executes (order is matched).
 | net_fee_paid | string | Net fee paid from wallet |
 | txn_ts | number | Transaction timestamp (Unix seconds) |
 
+
 ---
+
 
 ## Reference
 
@@ -385,7 +393,9 @@ For backward compatibility, you can map new statuses to old statuses:
 | `429` | Too Many Connections - Maximum of 5 concurrent connections per API key exceeded |
 | `500` | Internal Server Error |
 
+
 ---
+
 
 ## Complete Example
 
@@ -540,7 +550,9 @@ function handleMatchUpdate(data) {
 connect();
 ```
 
+
 ---
+
 
 ## Security Best Practices
 

--- a/websocket-public.md
+++ b/websocket-public.md
@@ -2,7 +2,7 @@
 
 ## Announcement
 
-* **⚠️ 2026-05-18:** `market.trade.<symbol>` stream will be permanently closed. Please migrate to Private WebSocket.
+N/A — see [README.md](./README.md#announcement).
 
 ## Change Log
 

--- a/websocket-public.md
+++ b/websocket-public.md
@@ -1,9 +1,5 @@
 # WebSocket API — Public (2023-04-19)
 
-## Announcement
-
-N/A — see [README.md](./README.md#announcement).
-
 ## Change Log
 
 * 2026-05-18 `market.trade.<symbol>` stream will be permanently closed on 2026-05-18

--- a/websocket-public.md
+++ b/websocket-public.md
@@ -42,9 +42,11 @@ N/A — Connect directly to the stream URL. No subscribe/unsubscribe events need
 
 No explicit ping required. Reconnect on disconnect.
 
+<br>
 
 ---
 
+<br>
 
 ## Data Streams
 
@@ -81,9 +83,11 @@ Real-time matched order data. Each trade contains buy order id and sell order id
 | amt    | float  | Amount matched                          |
 | ts     | int    | Trade timestamp (Unix seconds)          |
 
+<br>
 
 ---
 
+<br>
 
 ### Ticker Stream
 
@@ -136,9 +140,11 @@ Real-time ticker data. Re-calculated on every order creation, cancellation, and 
 | open           | float  | Open price                               |
 | close          | float  | Close price                              |
 
+<br>
 
 ---
 
+<br>
 
 ### Live Order Book Stream
 
@@ -279,9 +285,11 @@ Real-time order book data using numeric symbol ID. Emits 5 event types: `bidscha
 | highestBid     | string | Highest bidding price               |
 | lowestAsk      | string | Lowest asking price                 |
 
+<br>
 
 ---
 
+<br>
 
 ## Reference
 
@@ -297,9 +305,11 @@ N/A — Public streams do not carry order status data.
 
 N/A — Public streams do not return structured error codes. Connection failures result in WebSocket disconnect.
 
+<br>
 
 ---
 
+<br>
 
 ## Complete Example
 

--- a/websocket-public.md
+++ b/websocket-public.md
@@ -148,20 +148,9 @@ Real-time ticker data. Re-calculated on every order creation, cancellation, and 
 orderbook.\<symbol-id\>
 
 #### Description:
-Real-time order book data using numeric symbol ID. Emits 5 event types: `bidschanged`, `askschanged`, `tradeschanged`, `depthchanged`, and `global.ticker`.
+Real-time order book data using numeric symbol ID. Emits 5 event types: `bidschanged`, `askschanged`, `tradeschanged`, `depthchanged`, and `global.ticker`. bidschanged/askschanged fire when a buy/sell order is opened, closed, or cancelled (max 30 orders each); tradeschanged fires on matched trades and is also sent as initial data on connect (max 30 each); depthchanged fires when order book depth changes; ticker/global.ticker aggregate the above per-symbol or across all symbols respectively.
 
-| Event         | Trigger                                                              | Max Depth |
-| ------------- | -------------------------------------------------------------------- | --------- |
-| bidschanged   | Any buy order opened/closed/cancelled on this symbol                 | 30 orders |
-| askschanged   | Any sell order opened/closed/cancelled on this symbol                | 30 orders |
-| tradeschanged | Orders matched on this symbol (also sent as initial data on connect) | 30 each   |
-| depthchanged  | Order book depth changed on this symbol                              | —         |
-| ticker        | Any of bidschanged/askschanged/tradeschanged fires on this symbol    | —         |
-| global.ticker | Any of bidschanged/askschanged/tradeschanged fires on any symbol     | —         |
-
-#### Response:
-
-**Event: bidschanged / askschanged**
+#### Response (bidschanged / askschanged):
 ```json
 {
   "data": [
@@ -172,7 +161,7 @@ Real-time order book data using numeric symbol ID. Emits 5 event types: `bidscha
 }
 ```
 
-**Event: tradeschanged**
+#### Response (tradeschanged):
 ```json
 {
   "data": [
@@ -185,7 +174,7 @@ Real-time order book data using numeric symbol ID. Emits 5 event types: `bidscha
 }
 ```
 
-**Event: depthchanged**
+#### Response (depthchanged):
 ```json
 {
   "data": {
@@ -203,7 +192,7 @@ Real-time order book data using numeric symbol ID. Emits 5 event types: `bidscha
 }
 ```
 
-**Event: global.ticker**
+#### Response (global.ticker):
 ```json
 {
   "data": {

--- a/websocket-public.md
+++ b/websocket-public.md
@@ -42,7 +42,9 @@ N/A — Connect directly to the stream URL. No subscribe/unsubscribe events need
 
 No explicit ping required. Reconnect on disconnect.
 
+
 ---
+
 
 ## Data Streams
 
@@ -79,7 +81,9 @@ Real-time matched order data. Each trade contains buy order id and sell order id
 | amt    | float  | Amount matched                          |
 | ts     | int    | Trade timestamp (Unix seconds)          |
 
+
 ---
+
 
 ### Ticker Stream
 
@@ -132,7 +136,9 @@ Real-time ticker data. Re-calculated on every order creation, cancellation, and 
 | open           | float  | Open price                               |
 | close          | float  | Close price                              |
 
+
 ---
+
 
 ### Live Order Book Stream
 
@@ -273,7 +279,9 @@ Real-time order book data using numeric symbol ID. Emits 5 event types: `bidscha
 | highestBid     | string | Highest bidding price               |
 | lowestAsk      | string | Lowest asking price                 |
 
+
 ---
+
 
 ## Reference
 
@@ -289,7 +297,9 @@ N/A — Public streams do not carry order status data.
 
 N/A — Public streams do not return structured error codes. Connection failures result in WebSocket disconnect.
 
+
 ---
+
 
 ## Complete Example
 


### PR DESCRIPTION
## What does this PR do and why?
Follow-up to #206 (merged). Three more commits were pushed to this branch after #206 already merged, so they never made it into `suwit-bitkub-new-docs`.

## Changes

**Separator spacing** (`rest-v1.md`, `rest-v3.md`, `rest-v4.md`, `websocket-public.md`, `websocket-private.md`)
- Every `---` separator now has exactly 2 blank lines before/after (was 1) for cleaner raw-source readability
- Added explicit `<br>` before and after each `---` so the extra spacing is actually visible when rendered on GitHub (blank-line count alone is collapsed by CommonMark, so it had no visual effect)

**Consolidate Announcement sections into README.md**
- Every doc file had its own `## Announcement` section, but `bitkub-api-document` only ever read the one from `rest-v3.md` — `rest-v4.md` and `websocket-public.md` each had real announcement content that was silently never surfaced anywhere
- Moved all real announcement content into a single `## Announcement` section in `README.md`, qualifying `rest-v3.md`'s previously-bare in-file anchors (`#post-apiv3fiataccounts` → `rest-v3.md#post-apiv3fiataccounts`) since a bare anchor now needs to point back into its source file rather than within README.md itself
- Each doc file's own `## Announcement` section now just points to README.md

## Test plan
- [ ] Confirm every `---` separator renders with visible extra spacing on GitHub
- [ ] Confirm README.md's Announcement section includes all previously-scattered content with working links

🤖 Generated with [Claude Code](https://claude.com/claude-code)